### PR TITLE
Fix Termolator path args

### DIFF
--- a/summary/auto_summary.py
+++ b/summary/auto_summary.py
@@ -317,7 +317,20 @@ def run_summary(): #runs the bash script for generating the summary.
             termolator_dir,
             'True']))
     elif lang_acronym == 'fr':
-        os.system(termolator_dir +'/run_termolator_fr.sh '+ subclass + ' ' + superclasses[0] + ' ' + subclass + '' +' True True True 30000 5000 '+ termolator_dir + ' ' + termolator_dir + '/TreeTaggerLinux -1')
+        subprocess.run([
+            termolator_dir + '/run_termolator_fr.sh',
+            subclass,
+            superclasses[0],
+            subclass,
+            'True',
+            'True',
+            'True',
+            '30000',
+            '5000',
+            termolator_dir,
+            termolator_dir + '/TreeTaggerLinux',
+            '-1'
+        ], check=True)
         os.system('python3 ' + termolator_dir +'/modified_symlink.py ' + './')
 
     else:


### PR DESCRIPTION
## Summary
- ensure French Termolator script gets correct paths

## Testing
- `python3 -m py_compile summary/auto_summary.py`

------
https://chatgpt.com/codex/tasks/task_e_6888f4b60e00832eba2025e8f51aed5f